### PR TITLE
Build docker image on ARM64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,6 +50,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64/v8
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.DOCKER_REGISTRY_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,8 @@
 name: Docker publish
 
 on:
+  pull-request:
+    branches: "*"
   push:
     branches:
       - 'master'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,21 @@ ENV VIRTUOSO_GIT_VERSION 7.2.9
 
 COPY patch.diff /patch.diff
 
-# Install prerequisites, Download, Patch, compile and install
+# Install prerequisites
 RUN apk add --update git automake autoconf automake libtool bison flex gawk gperf openssl \
-    g++ openssl-dev make patch xz-dev bzip2-dev && \
-    git clone -b v${VIRTUOSO_GIT_VERSION} --single-branch --depth=1 ${VIRTUOSO_GIT_URL} ${VIRTUOSO_DIR} && \
-    cd ${VIRTUOSO_DIR} && \
-    patch ${VIRTUOSO_DIR}/libsrc/Wi/sparql_io.sql < /patch.diff && \
-    ./autogen.sh && \
-    CFLAGS="-O2 -m64" && export CFLAGS && \
-    ./configure --disable-bpel-vad --enable-conductor-vad --enable-fct-vad --disable-dbpedia-vad --disable-demo-vad --disable-isparql-vad --disable-ods-vad --disable-sparqldemo-vad --disable-syncml-vad --disable-tutorial-vad --program-transform-name="s/isql/isql-v/" && \
-    make -j $(grep -c '^processor' /proc/cpuinfo) && \
-    make -j $(grep -c '^processor' /proc/cpuinfo) install
-
+    g++ openssl-dev make patch xz-dev bzip2-dev
+# Download sources
+RUN git clone -b v${VIRTUOSO_GIT_VERSION} --single-branch --depth=1 ${VIRTUOSO_GIT_URL} ${VIRTUOSO_DIR}
+WORKDIR ${VIRTUOSO_DIR}
+# Patch
+RUN patch ${VIRTUOSO_DIR}/libsrc/Wi/sparql_io.sql < /patch.diff
+# Complile
+RUN  ./autogen.sh
+RUN CFLAGS="-O2 -m64" && export CFLAGS && \
+    ./configure --disable-bpel-vad --enable-conductor-vad --enable-fct-vad --disable-dbpedia-vad --disable-demo-vad --disable-isparql-vad --disable-ods-vad --disable-sparqldemo-vad --disable-syncml-vad --disable-tutorial-vad --program-transform-name="s/isql/isql-v/"
+RUN make -j $(grep -c '^processor' /proc/cpuinfo)
+# Install
+RUN make -j $(grep -c '^processor' /proc/cpuinfo) install
 
 # Final image
 FROM alpine:3.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY patch.diff /patch.diff
 
 # Install prerequisites
 RUN apk add --update git automake autoconf automake libtool bison flex gawk gperf openssl \
-    g++ openssl-dev make patch xz-dev bzip2-dev
+    g++ openssl-dev make patch xz-dev bzip2-dev python3
 # Download sources
 RUN git clone -b v${VIRTUOSO_GIT_VERSION} --single-branch --depth=1 ${VIRTUOSO_GIT_URL} ${VIRTUOSO_DIR}
 WORKDIR ${VIRTUOSO_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ COPY virtuoso.ini dump_nquads_procedure.sql dump_one_graph_procedure.sql clean-l
 WORKDIR /data
 EXPOSE 8890 1111
 
-CMD sh /virtuoso/virtuoso.sh
+CMD ["/virtuoso/virtuoso.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ MAINTAINER Xavier Garnier 'xavier.garnier@irisa.fr'
 # Environment variables
 ENV VIRTUOSO_GIT_URL https://github.com/openlink/virtuoso-opensource.git
 ENV VIRTUOSO_DIR /virtuoso-opensource
-ENV VIRTUOSO_GIT_VERSION 7.2.9
+ENV VIRTUOSO_GIT_VERSION 7.2.14
 
 COPY patch.diff /patch.diff
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN ./autogen.sh && ./configure && make && make install
 FROM alpine:3.20 AS builder
 
 # Environment variables
-ENV VIRTUOSO_GIT_URL https://github.com/openlink/virtuoso-opensource.git
-ENV VIRTUOSO_DIR /virtuoso-opensource
-ENV VIRTUOSO_GIT_VERSION 7.2.14
+ENV VIRTUOSO_GIT_URL=https://github.com/openlink/virtuoso-opensource.git
+ENV VIRTUOSO_DIR=/virtuoso-opensource
+ENV VIRTUOSO_GIT_VERSION=7.2.14
 
 COPY patch.diff /patch.diff
 
@@ -35,7 +35,7 @@ RUN make -j $(grep -c '^processor' /proc/cpuinfo) install
 
 # Final image
 FROM alpine:3.20
-ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH
+ENV PATH=/usr/local/virtuoso-opensource/bin/:$PATH
 COPY --from=s3fs-builder  /usr/local/bin/s3fs /usr/local/bin/s3fs
 
 RUN apk add --no-cache --update openssl py-pip fuse libcurl libxml2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile s3fs in a separate image
-FROM alpine:3.17 AS s3fs-builder
+FROM alpine:3.20 AS s3fs-builder
 RUN apk add --update fuse fuse-dev automake gcc make libcurl curl-dev libxml2 libxml2-dev \
     openssl openssl-dev autoconf g++
 RUN wget https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.91.zip && \
@@ -8,7 +8,7 @@ WORKDIR s3fs-fuse-1.91
 RUN ./autogen.sh && ./configure && make && make install
 
 # Compile virtuoso in a separate image
-FROM alpine:3.17 AS builder
+FROM alpine:3.20 AS builder
 MAINTAINER Xavier Garnier 'xavier.garnier@irisa.fr'
 
 # Environment variables
@@ -35,7 +35,7 @@ RUN make -j $(grep -c '^processor' /proc/cpuinfo)
 RUN make -j $(grep -c '^processor' /proc/cpuinfo) install
 
 # Final image
-FROM alpine:3.17
+FROM alpine:3.20
 ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH
 COPY --from=s3fs-builder  /usr/local/bin/s3fs /usr/local/bin/s3fs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN make -j $(grep -c '^processor' /proc/cpuinfo) install
 
 # Final image
 FROM alpine:3.20
-ENV PATH=/usr/local/virtuoso-opensource/bin/:$PATH
+ENV PATH=/usr/local/virtuoso-opensource/bin/:/root/.local/bin:$PATH
 
-RUN apk add --no-cache --update openssl py-pip s3fs-fuse fuse libcurl libxml2 && \
-    pip install crudini && \
+RUN apk add --no-cache --update openssl s3fs-fuse fuse libcurl libxml2 pipx && \
+    pipx install crudini && \
     mkdir -p /usr/local/virtuoso-opensource/var/lib/virtuoso/db && \
     ln -s /usr/local/virtuoso-opensource/var/lib/virtuoso/db /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN ./autogen.sh && ./configure && make && make install
 
 # Compile virtuoso in a separate image
 FROM alpine:3.20 AS builder
-MAINTAINER Xavier Garnier 'xavier.garnier@irisa.fr'
 
 # Environment variables
 ENV VIRTUOSO_GIT_URL https://github.com/openlink/virtuoso-opensource.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,3 @@
-# Compile s3fs in a separate image
-FROM alpine:3.20 AS s3fs-builder
-RUN apk add --update fuse fuse-dev automake gcc make libcurl curl-dev libxml2 libxml2-dev \
-    openssl openssl-dev autoconf g++
-RUN wget https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.91.zip && \
-    unzip v1.91.zip
-WORKDIR s3fs-fuse-1.91
-RUN ./autogen.sh && ./configure && make && make install
-
 # Compile virtuoso in a separate image
 FROM alpine:3.20 AS builder
 
@@ -36,9 +27,8 @@ RUN make -j $(grep -c '^processor' /proc/cpuinfo) install
 # Final image
 FROM alpine:3.20
 ENV PATH=/usr/local/virtuoso-opensource/bin/:$PATH
-COPY --from=s3fs-builder  /usr/local/bin/s3fs /usr/local/bin/s3fs
 
-RUN apk add --no-cache --update openssl py-pip fuse libcurl libxml2 && \
+RUN apk add --no-cache --update openssl py-pip s3fs-fuse fuse libcurl libxml2 && \
     pip install crudini && \
     mkdir -p /usr/local/virtuoso-opensource/var/lib/virtuoso/db && \
     ln -s /usr/local/virtuoso-opensource/var/lib/virtuoso/db /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile s3fs in a separate image
-FROM alpine:3.16 AS s3fs-builder
+FROM alpine:3.17 AS s3fs-builder
 RUN apk add --update fuse fuse-dev automake gcc make libcurl curl-dev libxml2 libxml2-dev \
     openssl openssl-dev autoconf g++
 RUN wget https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.91.zip && \
@@ -8,13 +8,13 @@ WORKDIR s3fs-fuse-1.91
 RUN ./autogen.sh && ./configure && make && make install
 
 # Compile virtuoso in a separate image
-FROM alpine:3.16 AS builder
+FROM alpine:3.17 AS builder
 MAINTAINER Xavier Garnier 'xavier.garnier@irisa.fr'
 
 # Environment variables
 ENV VIRTUOSO_GIT_URL https://github.com/openlink/virtuoso-opensource.git
 ENV VIRTUOSO_DIR /virtuoso-opensource
-ENV VIRTUOSO_GIT_VERSION 7.2.8
+ENV VIRTUOSO_GIT_VERSION 7.2.9
 
 COPY patch.diff /patch.diff
 
@@ -32,7 +32,7 @@ RUN apk add --update git automake autoconf automake libtool bison flex gawk gper
 
 
 # Final image
-FROM alpine:3.16
+FROM alpine:3.17
 ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH
 COPY --from=s3fs-builder  /usr/local/bin/s3fs /usr/local/bin/s3fs
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ docker run --name my-virtuoso \
 ### dba password
 The `dba` password can be set at container start up via the `DBA_PASSWORD` environment variable. If not set, the default `dba` password will be used.
 
+/!\ The dba password will only be updated 'from the default password'. If you already changed the password from the default value, you will need to manually connect to the container, and update it to the new value using the *previous* password, as follows:
+
+```
+isql-v -U dba -P OLDPASSWORD
+user_set_password('dba', NEWPASSWORD');
+```
+
 ### SPARQL update permission
 The `SPARQL_UPDATE` permission on the SPARQL endpoint can be granted by setting the `SPARQL_UPDATE` environment variable to `true`.
 


### PR DESCRIPTION
- **chore: virtuoso 7.2.9**
- **chore: use multiple RUN instructions in builder image**
- **Update README.md**
- **chore: upgrade virtuoso to 7.2.14**
- **chore: upgrade alpine to 3.20**
- **refactor: remove deprecated MAINTAINER entry**
- **refactor: replace `ENV key value` with `ENV key=value` syntaxe**
- **refactor: use json syntaxe for CMD**
- **feat: use s3fs from package manager since it have fixed**
- **refactor: use pipx instead of pip to install crudini**
- **fix: missing python3 in build image**
- **ci(build): build image on arm64**
- **WIP: don't merge this stp**
